### PR TITLE
Add individual model check marks

### DIFF
--- a/contexts/AppContext.tsx
+++ b/contexts/AppContext.tsx
@@ -59,6 +59,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const [preferredDtype, setPreferredDtype] = useState<'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16'>('fp32');
   const [autoSelect, setAutoSelect] = useState(true);
   const [keepLocal, setKeepLocal] = useState(true);
+  const [modelKeepLocal, setModelKeepLocal] = useState<Record<string, boolean>>({});
 
   // Store pending read request during model download
   const [pendingRead, setPendingRead] = useState<{ text: string; voice: string } | null>(null);
@@ -450,6 +451,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
       preferredDtype,
       autoSelect,
       keepLocal,
+      modelKeepLocal,
     },
     selectedVoice,
     error,
@@ -490,6 +492,9 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
       setPreferredDtype: handleDtypeChange,
       setAutoSelect,
       setKeepLocal,
+      setModelKeepLocal: (modelId: string, keepLocal: boolean) => {
+        setModelKeepLocal((prev: Record<string, boolean>) => ({ ...prev, [modelId]: keepLocal }));
+      },
       setError,
       setIsSeekingHover,
       setHoverTime,

--- a/types.ts
+++ b/types.ts
@@ -46,6 +46,7 @@ export interface ModelState {
   preferredDtype: 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16';
   autoSelect: boolean;
   keepLocal: boolean;
+  modelKeepLocal: Record<string, boolean>; // Per-model local storage preferences
 }
 
 export interface TextSet {
@@ -136,6 +137,7 @@ export interface AppContextType {
     setPreferredDtype: (dtype: 'fp32' | 'fp16' | 'q8' | 'q4' | 'q4f16') => void;
     setAutoSelect: (enabled: boolean) => void;
     setKeepLocal: (enabled: boolean) => void;
+    setModelKeepLocal: (modelId: string, keepLocal: boolean) => void;
     
     // UI actions
     setError: (error: AppError | null) => void;


### PR DESCRIPTION
Replace global 'Keep models downloaded' setting with per-model local storage checkboxes to allow granular control over which models are stored locally.