### PR TITLE
Fix kittenTTS model integration crash

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -187,7 +187,7 @@ export interface AppContextType {
   // TTS hook data
   tts: {
     voices: Voice[];
-    speak: (text: string, voice: string) => Promise<void>;
+    speak: (text: string, voice: string, onProgress?: (percent: number) => void) => Promise<void>;
     stop: () => void;
     isPlaying: boolean;
     isLoading: boolean;


### PR DESCRIPTION
Fixes KittenTTS integration to prevent crashes and adds a progress callback.

The previous KittenTTS integration caused a crash when selected as the model due to two main issues:
1. The `sid` input tensor was incorrectly created with a plain `BigInt`, which `onnxruntime-web` cannot handle in browsers.
2. ONNX Runtime's WASM binaries were not being located because no default `wasmPaths` was set for this hook, leading to a 404 error and a hard failure.
These changes resolve those issues, allowing KittenTTS to function correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-a13539e0-e239-469f-a14d-91dc6f751992">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a13539e0-e239-469f-a14d-91dc6f751992">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

